### PR TITLE
Fix non unique request id

### DIFF
--- a/src/AWS/AWS.php
+++ b/src/AWS/AWS.php
@@ -231,8 +231,6 @@ class AWS
      */
     public function getRegion(): string
     {
-
-
         $endpoint = $this->_config->getEndpoint();
         $regionName = 'us-east-1';
 
@@ -253,7 +251,7 @@ class AWS
     {
         $amount = trim($amount);
         $payload = [
-           "creationRequestId" => $this->_config->getPartner() . "_" . time(),
+            'creationRequestId' => $creationId ?: uniqid($this->_config->getPartner().'_'),
             'partnerId' => $this->_config->getPartner(),
             'value' =>
                 [


### PR DESCRIPTION
This PR fixes `getGiftCardPayload()` responsible for building the payload for making a `create gift card` request.

1. Using `$creationId` argument if set instead of generating it.
2. If `creationRequestId` is not set and has to be generated, the generated value is not unique if multiple requests are made in the same second. `time()` returns a timestamp only with a seconds precision. `uniqueid()` instead generates an id using microseconds precision.