### PR TITLE
Fix readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ $ composer require kamerk22/amazongiftcode
 
 Set the following Environment Variable in `.env` file.
 ```bash
-GIFT_CARD_ENDPOINT=agcod-v2-gamma.amazon.com
+GIFT_CARD_ENDPOINT=https://agcod-v2-gamma.amazon.com
 GIFT_CARD_KEY=AWS_ACCESS_KEY
 GIFT_CARD_SECRET=AWS_SECRET
 GIFT_CARD_PARTNER_ID=AWS_PARTNER_ID

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ GIFT_CARD_ENDPOINT=https://agcod-v2-gamma.amazon.com
 GIFT_CARD_KEY=AWS_ACCESS_KEY
 GIFT_CARD_SECRET=AWS_SECRET
 GIFT_CARD_PARTNER_ID=AWS_PARTNER_ID
+GIFT_CARD_CURRENCY=USD
 ```
 
 The package will register itself automatically.


### PR DESCRIPTION
I don't know why the scheme name was removed, but the scheme name is necessary because the `GIFT_CARD_ENDPOINT` variable will be processed with the `parse_url` PHP function.

Also I add the `GIFT_CARD_CURRENCY` variable for world-wide developers.
